### PR TITLE
Correct wall time evaluation

### DIFF
--- a/CreatePar.py
+++ b/CreatePar.py
@@ -65,7 +65,7 @@ print("Potential_bruteforce_ref.dat is saved.\n")
 
 # Using tree
 print("Calculating the potential with pytreegrav...")
-p = Potential(pos,m,h,method='tree')
+p = Potential(pos,m,h,theta=theta, method='tree')
 f = open("./Potential_tree_ref.dat", "w")
 
 for i in range(N):

--- a/main.cpp
+++ b/main.cpp
@@ -87,12 +87,12 @@ int main( int argc, char* argv[] ) {
     // Store particles' properties
     ReadPar(Npar, pos, m, h, input);
 
+    double start = omp_get_wtime(); 
     Octree* tree = new Octree( Npar, pos, m, h );
 
     // Declare the array to store the potential
     double* phi = new double[Npar];
 
-    double start = omp_get_wtime();
     phi = PotentialTarget_tree(Npar, pos, h, tree, G, theta);
     double end   = omp_get_wtime();
 


### PR DESCRIPTION
- Correct wall time evaluation, which should start with building the tree.
- Add _theta_ when using pytreegrav.